### PR TITLE
Fixes for supply congestion issue

### DIFF
--- a/dev/Basic/medium/entities/Person_MT.cpp
+++ b/dev/Basic/medium/entities/Person_MT.cpp
@@ -60,16 +60,16 @@ const std::string& getModeString(int idx)
 Person_MT::Person_MT(const std::string& src, const MutexStrategy& mtxStrat, int id, std::string databaseID)
 : Person(src, mtxStrat, id, databaseID),
 isQueuing(false), distanceToEndOfSegment(0.0), drivingTimeToEndOfLink(0.0), remainingTimeThisTick(0.0),
-requestedNextSegStats(nullptr), canMoveToNextSegment(NONE), currSegStats(nullptr), currLane(nullptr),
-prevRole(nullptr), currRole(nullptr), nextRole(nullptr), numTicksStuck(0)
+requestedNextSegStats(nullptr), requestedNextLane(nullptr), canMoveToNextSegment(NONE), currSegStats(nullptr),
+currLane(nullptr), prevRole(nullptr), currRole(nullptr), nextRole(nullptr), numTicksStuck(0)
 {
 }
 
 Person_MT::Person_MT(const std::string& src, const MutexStrategy& mtxStrat, const std::vector<sim_mob::TripChainItem*>& tc)
 : Person(src, mtxStrat, tc),
 isQueuing(false), distanceToEndOfSegment(0.0), drivingTimeToEndOfLink(0.0), remainingTimeThisTick(0.0),
-requestedNextSegStats(nullptr), canMoveToNextSegment(NONE), currSegStats(nullptr), currLane(nullptr),
-prevRole(nullptr), currRole(nullptr), nextRole(nullptr), numTicksStuck(0)
+requestedNextSegStats(nullptr), requestedNextLane(nullptr), canMoveToNextSegment(NONE), currSegStats(nullptr),
+currLane(nullptr), prevRole(nullptr), currRole(nullptr), nextRole(nullptr), numTicksStuck(0)
 {
 	ConfigParams& cfg = ConfigManager::GetInstanceRW().FullConfig();
 	std::string ptPathsetStoredProcName = cfg.getDatabaseProcMappings().procedureMappings["pt_pathset"];

--- a/dev/Basic/medium/entities/Person_MT.hpp
+++ b/dev/Basic/medium/entities/Person_MT.hpp
@@ -19,6 +19,7 @@
 namespace sim_mob
 {
 
+class Lane;
 namespace medium
 {
 class Conflux;
@@ -116,6 +117,7 @@ public:
 
 	//Used by confluxes and movement facet of roles to move this person in the medium term
 	const SegmentStats* requestedNextSegStats;
+	const Lane* requestedNextLane;
 	bool laneUpdated = false;
 	const Lane * updatedLane = nullptr;
 	const SegmentStats * beforeUpdateSegStat = nullptr;

--- a/dev/Basic/medium/entities/conflux/Conflux.cpp
+++ b/dev/Basic/medium/entities/conflux/Conflux.cpp
@@ -427,13 +427,6 @@ UpdateStatus Conflux::update(timeslice frameNumber)
     }
     case 2:
     {
-        processStartingAgents();
-        numUpdatesThisTick = 3;
-        return UpdateStatus::ContinueIncomplete;
-
-    }
-    case 3:
-    {
         updateAndReportSupplyStats(currFrame);
         //reportLinkTravelTimes(currFrame);
         resetLinkTravelTimes(currFrame);
@@ -1659,7 +1652,6 @@ Entity::UpdateStatus Conflux::callMovementFrameTick(timeslice now, Person_MT* pe
             {
                 // nxtConflux is not processed for the current tick yet
                 int inOutCounter = currLnParams->getOutputCounter();
-                LaneParams * nxtLaneParams = person->requestedNextSegStats->getLaneParams(person->requestedNextLane);
 
                 // get maximum input counter among the lanes
                 LaneParams * laneToDecrement = nullptr;

--- a/dev/Basic/medium/entities/conflux/SegmentStats.cpp
+++ b/dev/Basic/medium/entities/conflux/SegmentStats.cpp
@@ -387,9 +387,9 @@ void SegmentStats::topCMergeLanesInSegment(PersonList& mergedPersonList)
 		}
 	}
 
-	//lane infinity persons handled in a separate update case
-	//LaneStats* lnInfStats =  laneStatsMap[laneInfinity];
-	//mergedPersonList.insert(mergedPersonList.end(), lnInfStats->laneAgents.begin(), lnInfStats->laneAgents.end());
+	//insert lane infinity persons at the tail of mergedPersonList
+	LaneStats* lnInfStats =  laneStatsMap[laneInfinity];
+	mergedPersonList.insert(mergedPersonList.end(), lnInfStats->laneAgents.begin(), lnInfStats->laneAgents.end());
 }
 
 std::pair<unsigned int, unsigned int> SegmentStats::getLaneAgentCounts(const Lane* lane) const

--- a/dev/Basic/medium/entities/conflux/SegmentStats.hpp
+++ b/dev/Basic/medium/entities/conflux/SegmentStats.hpp
@@ -105,13 +105,15 @@ private:
 	double outputFlowRate; //vehicles/s
 	double origOutputFlowRate; //vehicles/s
 	int outputCounter;
+	int inputCounter;
 	double acceptRate;
 	double fraction;
 	double lastAcceptTime;
 
 public:
 	LaneParams() :
-			outputFlowRate(0.0), origOutputFlowRate(0.0), outputCounter(0), acceptRate(0.0), fraction(0.0), lastAcceptTime(0.0)
+			outputFlowRate(0.0), origOutputFlowRate(0.0), outputCounter(0), inputCounter(0),
+			acceptRate(0.0), fraction(0.0), lastAcceptTime(0.0)
 	{
 	}
 
@@ -123,16 +125,16 @@ public:
 	{
 		return outputCounter;
 	}
+	int getInputCounter()
+	{
+		return inputCounter;
+	}
 	double getAcceptRate()
 	{
 		return acceptRate;
 	}
-
-	void setOutputCounter(int count)
-	{
-		outputCounter = count;
-	}
 	void decrementOutputCounter();
+	void decrementInputCounter();
 	void setOutputFlowRate(double output)
 	{
 		outputFlowRate = output;
@@ -288,6 +290,11 @@ public:
 	 * updates the output counter of lane
 	 */
 	void updateOutputCounter();
+
+	/**
+	 * updates the input counter of lane
+	 */
+	void updateInputCounter();
 
 	/**
 	 * updates the output flow rate of lane
@@ -460,14 +467,6 @@ protected:
 	/**taxiStandAgents for taxi-stand agents in this segment stats*/
 	std::vector<TaxiStandAgent*> taxiStandAgents;
 
-	/**
-	 * outermost lane in this segment stats.
-	 * This is a proper lane in the segment which is chosen by buses, taxis and
-	 * other vehicles (before moving into the virtual stopping lane) when they
-	 * have to stop in this segment stats.
-	 */
-	const Lane* outermostLane;
-
 	/** length of this SegmentStats in m */
 	double length;
 
@@ -564,9 +563,9 @@ public:
 		return statsNumberInSegment;
 	}
 
-	const Lane* getOutermostLane() const
+	const Lane* getInnermostLane() const
 	{
-		return outermostLane;
+		return *roadSegment->getLanes().begin();
 	}
 
 	double getSegSpeed(bool hasVehicle) const
@@ -874,6 +873,17 @@ public:
 	 * @param frameNumber the timeslice of current frame
 	 */
 	void updateLaneParams(timeslice frameNumber);
+
+	/**
+	 * update the initial queue length for a frame tick
+	 * @param frameNumber the timeslice of current frame
+	 */
+	void updateInitialQLength(timeslice frameNumber);
+
+	/**
+	 * update the input counter of lane for a frame tick
+	 */
+	void updateLaneInputCounter();
 
 	/**
 	 * report the statistics of this segment stats in string format

--- a/dev/Basic/medium/entities/roles/driver/DriverFacets.cpp
+++ b/dev/Basic/medium/entities/roles/driver/DriverFacets.cpp
@@ -869,16 +869,14 @@ void DriverMovement::flowIntoNextLinkIfPossible(DriverUpdateParams& params)
 			 * in the person object (the one we have permission to move to)
 			 * We must now, get permission for the the new next segment
 			 */
-			parentDriver->parent->requestedNextSegStats = pathMover.getNextSegStats(false);
+			nextSegStats = pathMover.getNextSegStats(false);
+			parentDriver->parent->requestedNextSegStats = nextSegStats;
+			parentDriver->parent->requestedNextLane = getBestTargetLane(nextSegStats, pathMover.getSecondSegStatsAhead());
 			parentDriver->parent->canMoveToNextSegment = Person_MT::NONE;
 
-			//Choose the current lane for the new next segment
-			nextSegStats = pathMover.getNextSegStats(false);
-			nextToNextSegStats = pathMover.getSecondSegStatsAhead();
-			currLane = getBestTargetLane(nextSegStats, nextToNextSegStats);
-			parentDriver->parent->requestedNextLane = currLane;
-
-			parentDriver->parent->setCurrSegStats(nextSegStats);
+			// set current lane and segment stats back to pathMover's current
+			currLane = getBestTargetLane(pathMover.getCurrSegStats(), nextSegStats);
+			parentDriver->parent->setCurrSegStats(pathMover.getCurrSegStats());
 			parentDriver->parent->setCurrLane(currLane);
 			isRouteChangedInVQ = true;
 			return;

--- a/dev/Basic/medium/entities/roles/driver/DriverFacets.cpp
+++ b/dev/Basic/medium/entities/roles/driver/DriverFacets.cpp
@@ -876,7 +876,9 @@ void DriverMovement::flowIntoNextLinkIfPossible(DriverUpdateParams& params)
 			nextSegStats = pathMover.getNextSegStats(false);
 			nextToNextSegStats = pathMover.getSecondSegStatsAhead();
 			currLane = getBestTargetLane(nextSegStats, nextToNextSegStats);
+			parentDriver->parent->requestedNextLane = currLane;
 
+			parentDriver->parent->setCurrSegStats(nextSegStats);
 			parentDriver->parent->setCurrLane(currLane);
 			isRouteChangedInVQ = true;
 			return;

--- a/dev/Basic/medium/entities/roles/driver/DriverFacets.hpp
+++ b/dev/Basic/medium/entities/roles/driver/DriverFacets.hpp
@@ -318,13 +318,29 @@ protected:
 	int getOutputCounter(const Lane* lane, const SegmentStats* segStats);
 
 	/**
-	 * set number of vehicles that can move out of a lane in this tick
+	 * decrement number of vehicles that can move out of a lane in this tick
 	 *
 	 * @param l lane in segment
-	 * @param count new value of outpur counter
 	 * @param segStats segStats segment stats corresponding to lane l's segment
 	 */
-	void setOutputCounter(const Lane* lane, int count, const SegmentStats* segStats);
+	void decrementOutputCounter(const Lane* lane, const SegmentStats* segStats);
+
+	/**
+	 * get the number of vehicles that can move into a lane in this tick
+	 *
+	 * @param l lane in segment
+	 * @param segStats segment stats corresponding to lane l's segment
+	 * @return num. of vehicles that can move in
+	 */
+	int getInputCounter(const Lane* lane, const SegmentStats* segStats);
+
+	/**
+	 * decrement number of vehicles that can move into a lane in this tick
+	 *
+	 * @param l lane in segment
+	 * @param segStats segStats segment stats corresponding to lane l's segment
+	 */
+	void decrementInputCounter(const Lane* lane, const SegmentStats* segStats);
 
 	double getOutputFlowRate(const Lane* lane);
 	double getAcceptRate(const Lane* lane, const SegmentStats* segStats);

--- a/dev/Basic/medium/entities/roles/driver/TaxiDriverFacets.cpp
+++ b/dev/Basic/medium/entities/roles/driver/TaxiDriverFacets.cpp
@@ -146,7 +146,7 @@ TaxiDriverMovement::getBestTargetLane(const SegmentStats *nextSegStats, const Se
 	if (mobilityServiceDriverStatus == DRIVE_TO_TAXISTAND && destinationTaxiStand && nextSegStats->hasTaxiStand(
 			destinationTaxiStand))
 	{
-		return nextSegStats->getOutermostLane();
+		return nextSegStats->getInnermostLane();
 	}
 	else
 	{

--- a/dev/Basic/shared/workers/WorkGroupManager.cpp
+++ b/dev/Basic/shared/workers/WorkGroupManager.cpp
@@ -262,7 +262,6 @@ void sim_mob::WorkGroupManager::waitAllGroups_DistributeMessages(std::set<Entity
             if (ConfigManager::GetInstance().FullConfig().RunningMidTerm())
             {
                 (*it)->processMultiUpdateEntities(removedEntities); // VQ
-                (*it)->processMultiUpdateEntities(removedEntities); // process agents in lane infinity
                 (*it)->processMultiUpdateEntities(removedEntities); // output & reset for next tick
             }
             else if (ConfigManager::GetInstance().FullConfig().RunningShortTerm())

--- a/dev/Basic/shared/workers/WorkGroupManager.cpp
+++ b/dev/Basic/shared/workers/WorkGroupManager.cpp
@@ -262,6 +262,7 @@ void sim_mob::WorkGroupManager::waitAllGroups_DistributeMessages(std::set<Entity
             if (ConfigManager::GetInstance().FullConfig().RunningMidTerm())
             {
                 (*it)->processMultiUpdateEntities(removedEntities); // VQ
+                (*it)->processMultiUpdateEntities(removedEntities); // process agents in lane infinity
                 (*it)->processMultiUpdateEntities(removedEntities); // output & reset for next tick
             }
             else if (ConfigManager::GetInstance().FullConfig().RunningShortTerm())


### PR DESCRIPTION
Added input counter to control flow of vehicles into a lane. Added new updating phase after vqueue upate phase to process agents in lane infinity. Changed updating of initial queue length to happen every frame tick instead of every update interval. Changed how drivers choose a best target lane. Fixed a bug where buses and taxis prefer the outermost lane instead of innermost lane when arriving at a stop/stand.