### PR TITLE
Fixed warnings, errors, code cleanup

### DIFF
--- a/dev/Basic/CMakeLists.txt
+++ b/dev/Basic/CMakeLists.txt
@@ -104,6 +104,64 @@ MACRO (TODAY RESULT)
 ENDMACRO (TODAY)
 
 
+#Option: build tests. Use the cmake gui to change this on a per-user basis.
+option(BUILD_TESTS "Build unit tests." OFF)
+
+#Option: build tests for long term model. Use the cmake gui to change this on a per-user basis.
+option(BUILD_TESTS_LONG "Build unit tests." OFF)
+
+#Option: build short term. Use the cmake gui to change this on a per-user basis.
+option(BUILD_SHORT "Build short-term simulator." ON)
+
+#Option: build medium term. Use the cmake gui to change this on a per-user basis.
+option(BUILD_MEDIUM "Build medium-term simulator." ON)
+
+#Option: build long term. Use the cmake gui to change this on a per-user basis.
+option(BUILD_LONG "Build long-term simulator." ON)
+
+#Option: build short/medium/long as libraries. Use the cmake gui to change this on a per-user basis.
+option(BUILD_LIBS "If true, builds the short, medium, and long-term code as libraries (to be installed in sim_mob_short,sim_mob_mid,sim_mob_long." OFF)
+
+#Option: Static building SimMobility. Currently static building doesn't work with Ubuntu 16.04
+option(BUILD_STATIC "If true, SimMobility is built in static mode." ON)
+
+#Option: Run SimMobility to only produce an input XML file for itself
+option(SIMMOB_XML_WRITER "Sim Mobility will print the network as an XML file." OFF)
+
+#Option: USE XML file as SimMobility input. Note that this uses the partial xml reader by default;
+#        It is not possible to turn on the old XML readers any more (just set this flag in your CMakeCache file).
+#option(SIMMOB_XML_READER "Load from XML, not the database" OFF)
+
+#Option: Turn on Unity (full-file) builds.
+option(SIMMOB_FULL_FAST_BUILD_DEBUG "Turn on full/fast builds in debug mode. This will greatly speed up compilation, but will force a full rebuild each time." OFF)
+option(SIMMOB_FULL_FAST_BUILD_RELEASE "Turn on full/fast builds in release mode. This will greatly speed up compilation, but will force a full rebuild each time." OFF)
+
+#String "option"; allows easier mangling of XML_READER until we get the new Config syntax working.
+#set(SIMMOB_XML_IN_FILE "" CACHE STRING "If non-empty, the XML_READER will attempt to read this instead of whatever is listed in simpleconf.cpp")
+
+#Option: strict error handling. Use the cmake gui to change this on a per-user basis.
+option (SIMMOB_STRICT_AGENT_ERRORS  "All unexpected and potentially dangerous behavior causes Agents to throw exceptions. If OFF, Agents will generally just remove themselves from the simulation in case of error." OFF)
+
+#Option: disable output. Use the cmake gui to change this on a per-user basis.
+option (SIMMOB_DISABLE_OUTPUT  "Disable all mutex-locked output and all additional non-trivial output. Avoid all use of mutexes w.r.t. output." OFF)
+
+#Option: disable MPI. Use the cmake gui to change this on a per-user basis.
+option (SIMMOB_DISABLE_MPI  "Disable all included files, libraries, and code segments that require MPI." ON)
+
+#Option: compile with c++0x. Use the cmake gui to change this on a per-user basis.
+option (SIMMOB_LATEST_STANDARD  "Attempt to compile Sim Mobility with the latest version of C++ (2011). Untested." ON)
+
+#Option: profiling flags. Use the cmake gui to change this on a per-user basis.
+option(SIMMOB_PROFILE_ON "Turn on profiling. If this flag is off, all SIMMOB_PROFILE_* options will be treated as effectively off." OFF)
+option(SIMMOB_PROFILE_AGENT_UPDATES "Log all Agent update ticks per thread and start time. Useful for debugging parallelization errors, but very slow." OFF)
+option(SIMMOB_PROFILE_WORKER_UPDATES "Log all Worker update ticks, including start and end time. This can be used to measure the real-world cost of threading, but is only likely accurate if frame ticks are relatively large (~100ms). Also very slow." OFF)
+option(SIMMOB_PROFILE_AURAMGR "Log the time taken to update the Aura Manager's spatial index. Usually combined with PROFILE_WORKER_UPDATES. Can be slow." OFF)
+option(SIMMOB_PROFILE_COMMSIM "Log the various stages of the Broker's update phase, including network communication and waiting on Agents. Can be slow." OFF)
+
+#Option: interactive mode flag (for the GUI)
+option(SIMMOB_INTERACTIVE_MODE "Force Sim Mobility to synchronize interactively with the GUI or console." OFF)
+
+
 ##################################################
 ## CPack Configuration
 ##################################################
@@ -188,63 +246,6 @@ IF( CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   ENDIF()
 ENDIF( CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" )
-
-#Option: build tests. Use the cmake gui to change this on a per-user basis.
-option(BUILD_TESTS "Build unit tests." OFF)
-
-#Option: build tests for long term model. Use the cmake gui to change this on a per-user basis.
-option(BUILD_TESTS_LONG "Build unit tests." OFF)
-
-#Option: build short term. Use the cmake gui to change this on a per-user basis.
-option(BUILD_SHORT "Build short-term simulator." ON)
-
-#Option: build medium term. Use the cmake gui to change this on a per-user basis.
-option(BUILD_MEDIUM "Build medium-term simulator." ON)
-
-#Option: build long term. Use the cmake gui to change this on a per-user basis.
-option(BUILD_LONG "Build long-term simulator." ON)
-
-#Option: build short/medium/long as libraries. Use the cmake gui to change this on a per-user basis.
-option(BUILD_LIBS "If true, builds the short, medium, and long-term code as libraries (to be installed in sim_mob_short,sim_mob_mid,sim_mob_long." OFF)   
-
-#Option: Static building SimMobility. Currently static building doesn't work with Ubuntu 16.04
-option(BUILD_STATIC "If true, SimMobility is built in static mode." ON)
-
-#Option: Run SimMobility to only produce an input XML file for itself
-option(SIMMOB_XML_WRITER "Sim Mobility will print the network as an XML file." OFF)
-
-#Option: USE XML file as SimMobility input. Note that this uses the partial xml reader by default;
-#        It is not possible to turn on the old XML readers any more (just set this flag in your CMakeCache file).
-#option(SIMMOB_XML_READER "Load from XML, not the database" OFF)
-
-#Option: Turn on Unity (full-file) builds. 
-option(SIMMOB_FULL_FAST_BUILD_DEBUG "Turn on full/fast builds in debug mode. This will greatly speed up compilation, but will force a full rebuild each time." OFF)
-option(SIMMOB_FULL_FAST_BUILD_RELEASE "Turn on full/fast builds in release mode. This will greatly speed up compilation, but will force a full rebuild each time." OFF)
-
-#String "option"; allows easier mangling of XML_READER until we get the new Config syntax working.
-#set(SIMMOB_XML_IN_FILE "" CACHE STRING "If non-empty, the XML_READER will attempt to read this instead of whatever is listed in simpleconf.cpp")
-
-#Option: strict error handling. Use the cmake gui to change this on a per-user basis.
-option (SIMMOB_STRICT_AGENT_ERRORS  "All unexpected and potentially dangerous behavior causes Agents to throw exceptions. If OFF, Agents will generally just remove themselves from the simulation in case of error." OFF)
-
-#Option: disable output. Use the cmake gui to change this on a per-user basis.
-option (SIMMOB_DISABLE_OUTPUT  "Disable all mutex-locked output and all additional non-trivial output. Avoid all use of mutexes w.r.t. output." OFF)
-
-#Option: disable MPI. Use the cmake gui to change this on a per-user basis.
-option (SIMMOB_DISABLE_MPI  "Disable all included files, libraries, and code segments that require MPI." ON)
-
-#Option: compile with c++0x. Use the cmake gui to change this on a per-user basis.
-option (SIMMOB_LATEST_STANDARD  "Attempt to compile Sim Mobility with the latest version of C++ (2011). Untested." ON)
-
-#Option: profiling flags. Use the cmake gui to change this on a per-user basis.
-option(SIMMOB_PROFILE_ON "Turn on profiling. If this flag is off, all SIMMOB_PROFILE_* options will be treated as effectively off." OFF)
-option(SIMMOB_PROFILE_AGENT_UPDATES "Log all Agent update ticks per thread and start time. Useful for debugging parallelization errors, but very slow." OFF)
-option(SIMMOB_PROFILE_WORKER_UPDATES "Log all Worker update ticks, including start and end time. This can be used to measure the real-world cost of threading, but is only likely accurate if frame ticks are relatively large (~100ms). Also very slow." OFF)
-option(SIMMOB_PROFILE_AURAMGR "Log the time taken to update the Aura Manager's spatial index. Usually combined with PROFILE_WORKER_UPDATES. Can be slow." OFF)
-option(SIMMOB_PROFILE_COMMSIM "Log the various stages of the Broker's update phase, including network communication and waiting on Agents. Can be slow." OFF) 
-
-#Option: interactive mode flag (for the GUI)
-option(SIMMOB_INTERACTIVE_MODE "Force Sim Mobility to synchronize interactively with the GUI or console." OFF)
 
 #Force gcc to output single line errors. 
 # This makes it easier for Eclipse to parse and understand each error.

--- a/dev/Basic/medium/behavioral/lua/PredayLuaModel.cpp
+++ b/dev/Basic/medium/behavioral/lua/PredayLuaModel.cpp
@@ -460,6 +460,7 @@ int sim_mob::medium::PredayLuaModel::predictTourTimeOfDay(PersonParams& personPa
         LuaRef retVal = chooseTTD(&personParams, &tourTimeOfDayParams);
         return retVal.cast<int>();
     }
+    throw std::runtime_error("Error. Empty model name in PredayLuaModel::predictTourTimeOfDay.");
 }
 
 int sim_mob::medium::PredayLuaModel::generateIntermediateStop(PersonParams& personParams, StopGenerationParams& isgParams) const

--- a/dev/Basic/medium/entities/conflux/Conflux.cpp
+++ b/dev/Basic/medium/entities/conflux/Conflux.cpp
@@ -2503,6 +2503,8 @@ Conflux* Conflux::findStartingConflux(Person_MT* person, unsigned int now)
             return MT_Config::getInstance().getConfluxNodes().begin()->second;
         }
     }
+    default:
+    	throw std::runtime_error("Error. Person role switch case is not defined in Conflux::findStartingConflux.");
     }
 }
 

--- a/dev/Basic/medium/entities/conflux/SegmentStats.cpp
+++ b/dev/Basic/medium/entities/conflux/SegmentStats.cpp
@@ -993,7 +993,7 @@ std::string SegmentStats::reportSegmentStats(uint32_t frameNumber)
 	if (ConfigManager::GetInstance().CMakeConfig().OutputEnabled())
 	{
 		char segStatBuf[100];
-		sprintf(segStatBuf, "seg,%u,%u,%u,%.2f,%u,%.2f,%u,%.2f,%u,%.2f,%u,%.2f,%d,%.2f\n",
+		sprintf(segStatBuf, "seg,%u,%u,%u,%.2f,%u,%.2f,%u,%.2f,%u,%.2f,%u,%.2f,%d,%.2f,%.2f,%.2f,%u\n",
 				frameNumber,
 				roadSegment->getRoadSegmentId(),
 				statsNumberInSegment,

--- a/dev/Basic/medium/entities/roles/driver/MesoReroute.cpp
+++ b/dev/Basic/medium/entities/roles/driver/MesoReroute.cpp
@@ -114,7 +114,7 @@ bool MesoReroute::doReroute()
 ////    logger << "New Path: " <<  MesoPathMover::printPath(newSS_Path);
 ////    std::cout << "[" << this << "] New Path: " <<  MesoPathMover::printPath(newSS_Path);
 ////    //debug...
-
+    return true;
 }
 
 bool MesoReroute::reroute()
@@ -125,6 +125,7 @@ bool MesoReroute::reroute()
      return false;
     }
 
-    doReroute();
+    bool res = doReroute();
     postReroute();
+    return res;
 }

--- a/dev/Basic/medium/entities/roles/driver/OnCallDriver.cpp
+++ b/dev/Basic/medium/entities/roles/driver/OnCallDriver.cpp
@@ -395,6 +395,14 @@ void OnCallDriver::subscribeToController()
             << subscribedCtrlr << ", but no controller of that id is registered";
         throw std::runtime_error(msg.str());
     }
+
+    if (!dynamic_cast<OnCallController *>(*it))
+    {
+        std::stringstream msg;
+        msg << "OnCallDriver " << parent->getDatabaseId() << " wants to subscribe to id "
+            << subscribedCtrlr << ", but controller is not of class OnCallController";
+        throw std::runtime_error(msg.str());
+    }
 #endif
 
     MessageBus::PostMessage(*it, MSG_DRIVER_SUBSCRIBE, MessageBus::MessagePtr(new DriverSubscribeMessage(parent)));
@@ -731,6 +739,7 @@ void OnCallDriver::removeDriverEntryFromAllContainer()
     const vector<MobilityServiceController *> & driverSubscribedToController  = getSubscribedControllers();
     for(auto it = driverSubscribedToController.begin(); it !=driverSubscribedToController.end(); ++it)
     {
+        auto pController = (OnCallController *)(*it);
         if(getDriverStatus()== MobilityServiceDriverStatus::DRIVE_START )
         {
             /* If Person is not yet started  & going to be removed Mean it's call from findStartingConflux is fail & This person will not Loaded to Simulation at all
@@ -744,16 +753,16 @@ void OnCallDriver::removeDriverEntryFromAllContainer()
 
 
         }
-        else if((*it)->getControllerCopyDriverSchedulesMap().find(thisDriver)== (*it)->getControllerCopyDriverSchedulesMap().end())
+        else if(pController->getControllerCopyDriverSchedulesMap().find(thisDriver)== pController->getControllerCopyDriverSchedulesMap().end())
         {
             ControllerLog()<<" Driver "<<thisDriver->getDatabaseId()<<"have  started  to move (Driver_STATUS = CRUISE)." \
                     " Subscription is sent, But Subscription is not recieved yet. In such case we are removing driver's entry from availableDrivers list before deletion."<<endl;
 
-            (*it)->getAvailableDriverSet().erase(thisDriver);
+            pController->getAvailableDriverSet().erase(thisDriver);
         }
         else
         {
-            Schedule &thisDriverScheduleControllerCopy = (*it)->getControllerCopyDriverSchedulesMap().at(thisDriver);
+            Schedule &thisDriverScheduleControllerCopy = pController->getControllerCopyDriverSchedulesMap().at(thisDriver);
             while (!thisDriverScheduleControllerCopy.empty())
             {
                 thisDriverScheduleControllerCopy.pop_back();

--- a/dev/Basic/medium/entities/roles/driver/TrainDriver.cpp
+++ b/dev/Basic/medium/entities/roles/driver/TrainDriver.cpp
@@ -119,6 +119,7 @@ Role<Person_MT>* TrainDriver::clone(Person_MT *parent) const
 		movement->setParentDriver(driver);
 		return driver;
 	}
+    return nullptr;
 }
 
 void TrainDriver::setNextDriver(TrainDriver* driver)
@@ -548,6 +549,7 @@ const TrainTrip* TrainDriver::getTrainTrip() const
 		const TrainTrip* trip = dynamic_cast<const TrainTrip*>(*currTrip);
 		return trip ;
 	}
+    return nullptr;
 }
 
 int TrainDriver::getTrainId() const

--- a/dev/Basic/medium/entities/roles/driver/TrainDriverFacets.cpp
+++ b/dev/Basic/medium/entities/roles/driver/TrainDriverFacets.cpp
@@ -2066,6 +2066,7 @@ bool TrainMovement::leaveFromPlaform()
 		startTimeOfNextStationStretch = params.now.ms() + params.secondsInTick;
 		return true;
 	}
+    return false;
 }
 
 
@@ -2146,6 +2147,7 @@ bool TrainMovement::updatePlatformsList(bool &isToBeRemoved)
 				reAssignTrainsToStationAgent(oldPlatform, next, isToBeRemoved);
 			}
 		}
+        return true;
 	}
 }
 

--- a/dev/Basic/medium/entities/roles/driver/TrainPathMover.cpp
+++ b/dev/Basic/medium/entities/roles/driver/TrainPathMover.cpp
@@ -212,6 +212,7 @@ PolyPoint TrainPathMover::GetStopPoint(double distance) const
         }
         curr++;
     }
+    throw std::runtime_error("Error. Unable to find stop point in TrainPathMover::GetStopPoint.");
 }
 double TrainPathMover::calcDistanceBetweenTwoPoints(std::vector<PolyPoint>::const_iterator& currPointItr,std::vector<PolyPoint>::const_iterator& laterPoint,const std::vector<PolyPoint> &points) const
 {

--- a/dev/Basic/medium/models/EnergyModelBase.cpp
+++ b/dev/Basic/medium/models/EnergyModelBase.cpp
@@ -44,6 +44,7 @@ void EnergyModelBase::computeTrainEnergyWithSpeed(const double trainMovement, st
 
 struct0_T EnergyModelBase::initVehicleStruct(const std::string drivetrain)
 {
+    return {};
 }
 
 

--- a/dev/Basic/medium/models/EnergyModelBase.hpp
+++ b/dev/Basic/medium/models/EnergyModelBase.hpp
@@ -156,7 +156,7 @@ public:
 	 * @param key 
 	 * @param val
 	 */
-	std::map<std::string, std::string>& setParams(std::string key,
+	void setParams(std::string key,
 			std::string val) {
 		paramsMapping[key] = val;
 	}

--- a/dev/Basic/shared/behavioral/lua/WithindayLuaModel.cpp
+++ b/dev/Basic/shared/behavioral/lua/WithindayLuaModel.cpp
@@ -117,13 +117,14 @@ int sim_mob::WithindayLuaModel::chooseMode(const PersonParams& personParams, con
 {
     const std::unordered_map<int, ActivityTypeConfig> &activityTypes = ConfigManager::GetInstance().FullConfig().getActivityTypeConfigMap();
     const std::string& modelName = activityTypes.at(wdModeParams.getTripType()).withinDayModeChoiceModel;
-    if (modelName.empty())
+    if (!modelName.empty())
     {
         std::string luaFunc = "choose_" + modelName;
         LuaRef chooseWDM = getGlobal(state.get(), luaFunc.c_str());
         LuaRef retVal = chooseWDM(&personParams, &wdModeParams);
         return retVal.cast<int>();
     }
+    throw std::runtime_error("Error. Mode name is empty in WithindayLuaModel::chooseMode.");
 }
 
 const WithindayLuaModel& sim_mob::WithindayLuaProvider::getWithindayModel()

--- a/dev/Basic/shared/conf/Constructs.cpp
+++ b/dev/Basic/shared/conf/Constructs.cpp
@@ -69,7 +69,7 @@ void sim_mob::Credential::LoadCredFile(const std::string& path)
     std::ifstream inFile(path.c_str(), std::ifstream::binary);
     if (!reader.parse(inFile, root, false)) {
         Warn() <<"Could not parse json credentials file: " <<path <<std::endl;
-        Warn() <<reader.getFormatedErrorMessages() <<std::endl;
+        Warn() <<reader.getFormattedErrorMessages() <<std::endl;
         return;
     }
 

--- a/dev/Basic/shared/database/PG_BulkInserter.cpp
+++ b/dev/Basic/shared/database/PG_BulkInserter.cpp
@@ -73,7 +73,7 @@ bool PG_BulkInserter::bulkInsert()
         }
     }
 
-    copyToDB(streamBuf);
+    return copyToDB(streamBuf);
 }
 
 bool PG_BulkInserter::copyToDB(const std::string& buffer)

--- a/dev/Basic/shared/entities/TrainController.cpp
+++ b/dev/Basic/shared/entities/TrainController.cpp
@@ -394,6 +394,7 @@ namespace sim_mob
         {
             return it->second;
         }
+        return {};
     }
     template<typename PERSON>
     void TrainController<PERSON>::frame_output(timeslice now)
@@ -840,6 +841,7 @@ namespace sim_mob
                 return (*it);
             }
         }
+        return {};
     }
 
     template<typename PERSON>
@@ -1367,8 +1369,8 @@ namespace sim_mob
                 trainIds.erase(trainIds.begin());
             }
             inActivePoolLock.unlock();
-            return trainId;
         }
+        return trainId;
     }
 
     template<typename PERSON>

--- a/dev/Basic/shared/entities/controllers/MobilityServiceController.hpp
+++ b/dev/Basic/shared/entities/controllers/MobilityServiceController.hpp
@@ -138,16 +138,6 @@ public:
     * @param person Driver to be removed
     */
     virtual void unsubscribeDriver(Person *person);
-
-    virtual std::map<const Person*, Schedule> & getControllerCopyDriverSchedulesMap()
-    {
-        //Do Nothing
-    }
-
-    virtual std::set<const Person *> getAvailableDriverSet()
-    {
-        //Do Nothing
-    }
 };
 
 

--- a/dev/Basic/shared/geospatial/aimsun/LaneLoader.cpp
+++ b/dev/Basic/shared/geospatial/aimsun/LaneLoader.cpp
@@ -215,6 +215,7 @@ vector<LinkHelperStruct> buildLinkHelperStruct(map<int, Node>& nodes, map<int, S
 
     return actRes;
 */
+    return {};
 }
 
 

--- a/dev/Basic/shared/network/tcp_server.cpp
+++ b/dev/Basic/shared/network/tcp_server.cpp
@@ -28,8 +28,8 @@ sim_mob::tcp_server::tcp_server(boost::asio::io_service& io_service,int port, Co
 
 void sim_mob::tcp_server::start_accept()
 {
-  new_connection =
-    tcp_connection::create(acceptor_.get_io_service());
+  //new_connection =
+  //  tcp_connection::create(acceptor_.get_io_service());
 
   acceptor_.async_accept(new_connection->socket(),
       boost::bind(&tcp_server::handle_accept, this, new_connection,

--- a/dev/Basic/shared/partitions/PackageUtils.hpp
+++ b/dev/Basic/shared/partitions/PackageUtils.hpp
@@ -46,7 +46,7 @@ class PackageUtils {
 
 public:
     PackageUtils() CHECK_MPI_THROW ;
-    ~PackageUtils() CHECK_MPI_THROW ;
+    ~PackageUtils() {};
 public:
     /**
      * DATA_TYPE can be:

--- a/dev/Basic/shared/partitions/UnPackageUtils.hpp
+++ b/dev/Basic/shared/partitions/UnPackageUtils.hpp
@@ -51,7 +51,7 @@ private:
 
 public:
     UnPackageUtils(std::string data) CHECK_MPI_THROW ;
-    ~UnPackageUtils() CHECK_MPI_THROW ;
+    ~UnPackageUtils() {};
 
     template<class DATA_TYPE>
     void operator>>(DATA_TYPE& value) CHECK_MPI_THROW ;

--- a/dev/Basic/shared/path/PathSetManager.cpp
+++ b/dev/Basic/shared/path/PathSetManager.cpp
@@ -1343,7 +1343,7 @@ int sim_mob::PrivatePathsetGenerator::genK_ShortestPath(boost::shared_ptr<sim_mo
     return kspn;
 }
 
-int sim_mob::PrivatePathsetGenerator::genSDLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &SDLE_Storage)
+void sim_mob::PrivatePathsetGenerator::genSDLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &SDLE_Storage)
 {
     const sim_mob::Link *curLink = nullptr;
     std::set<const Link*> blackList = std::set<const Link*>();
@@ -1398,7 +1398,7 @@ int sim_mob::PrivatePathsetGenerator::genSDLE(boost::shared_ptr<sim_mob::PathSet
     }
 }
 
-int sim_mob::PrivatePathsetGenerator::genSTTLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &STTLE_Storage)
+void sim_mob::PrivatePathsetGenerator::genSTTLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &STTLE_Storage)
 {
     const sim_mob::Link *curLink = nullptr;
     std::set<const Link*> blackList = std::set<const Link*>();
@@ -1460,7 +1460,7 @@ int sim_mob::PrivatePathsetGenerator::genSTTLE(boost::shared_ptr<sim_mob::PathSe
     } //if sinPathTravelTimeDefault
 }
 
-int sim_mob::PrivatePathsetGenerator::genSTTHBLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &STTHBLE_Storage)
+void sim_mob::PrivatePathsetGenerator::genSTTHBLE(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &STTHBLE_Storage)
 {
     const sim_mob::Link *curLink = nullptr;
     std::set<const Link*> blackList = std::set<const Link*>();
@@ -1522,7 +1522,7 @@ int sim_mob::PrivatePathsetGenerator::genSTTHBLE(boost::shared_ptr<sim_mob::Path
     } //if sinPathTravelTimeDefault
 }
 
-int sim_mob::PrivatePathsetGenerator::genRandPert(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &RandPertStorage)
+void sim_mob::PrivatePathsetGenerator::genRandPert(boost::shared_ptr<sim_mob::PathSet> &ps, std::vector<PathSetWorkerThread*> &RandPertStorage)
 {
     std::string fromToID(getFromToString(ps->subTrip.origin.node->getNodeId(), ps->subTrip.destination.node->getNodeId()));
     A_StarShortestTravelTimePathImpl * sttpImpl = (A_StarShortestTravelTimePathImpl*) stdir.getTravelTimeImpl();

--- a/dev/Basic/shared/path/PathSetManager.hpp
+++ b/dev/Basic/shared/path/PathSetManager.hpp
@@ -235,7 +235,7 @@ private:
       * @param SDLE_Storage output
       * @returns the number of paths generated (0 or 1)
       */
-     int genSDLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &SDLE_Storage);
+     void genSDLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &SDLE_Storage);
 
      /**
       * generate path by shortest travel time link elimination
@@ -243,7 +243,7 @@ private:
       * @param STTLE_Storage output
       * @returns the number of paths generated (0 or 1)
       */
-     int genSTTLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &STTLE_Storage);
+     void genSTTLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &STTLE_Storage);
 
      /**
       * generate path by shortest travel time link elimination with highway bias
@@ -251,7 +251,7 @@ private:
       * @param STTHBLE_Storage output
       * @returns the number of paths generated (0 or 1)
       */
-     int genSTTHBLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &STTHBLE_Storage);
+     void genSTTHBLE(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &STTHBLE_Storage);
 
      /**
       * generate path by random perturbation
@@ -259,7 +259,7 @@ private:
       * @param RandPertStorage output
       * @returns the number of paths generated (0 or 1)
       */
-     int genRandPert(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &RandPertStorage);
+     void genRandPert(boost::shared_ptr<sim_mob::PathSet> &ps,std::vector<PathSetWorkerThread*> &RandPertStorage);
 
      /**
       * set some tags as a result of comparing attributes among paths in a pathset

--- a/dev/Basic/shared/util/Utils.cpp
+++ b/dev/Basic/shared/util/Utils.cpp
@@ -14,7 +14,7 @@
 
 #include <fstream>
 #include <stdexcept>
-#include <proj_api.h>
+//#include <proj_api.h>
 #include <boost/random.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/thread/thread.hpp>
@@ -145,7 +145,7 @@ void Utils::printAndDeleteLogFiles(const std::list<std::string>& logFileNames,st
 
 void Utils::convertWGS84_ToUTM(double& x, double& y)
 {
-    projPJ pj_latlong, pj_utm;
+/*    projPJ pj_latlong, pj_utm;
 
     if (!(pj_latlong = pj_init_plus("+proj=longlat +datum=WGS84")))
     {
@@ -161,7 +161,7 @@ void Utils::convertWGS84_ToUTM(double& x, double& y)
     x *= DEG_TO_RAD;
     y *= DEG_TO_RAD;
 
-    pj_transform(pj_latlong, pj_utm, 1, 1, &x, &y, NULL);
+    pj_transform(pj_latlong, pj_utm, 1, 1, &x, &y, NULL);*/
 }
 
 std::pair<double, double> Utils::parseScaleMinmax(const std::string& src)

--- a/dev/Basic/short/config/ExpandShortTermConfigFile.cpp
+++ b/dev/Basic/short/config/ExpandShortTermConfigFile.cpp
@@ -144,6 +144,7 @@ Trip* MakePseudoTrip(unsigned int personId, const Node *origin, const Node *dest
             msg << "Invalid destination specified for person " << personId;
             throw std::runtime_error(msg.str());
         }
+        return nullptr;
     }
 }
 

--- a/dev/Basic/short/entities/amodController/amodBase/SimulatorBasic.cpp
+++ b/dev/Basic/short/entities/amodController/amodBase/SimulatorBasic.cpp
@@ -467,6 +467,7 @@ double SimulatorBasic::getDrivingDistance(int fromLocId, int toLocId) {
     if (fromLocId && toLocId) {
         return getDistance(state.getLocation(fromLocId).getPosition(), state.getLocation(toLocId).getPosition());
     }
+    return 0.0;
 }
 
 double SimulatorBasic::getDistance(const amod::Position &from, const amod::Position &to) {

--- a/dev/Basic/short/entities/fmodController/FMOD_Client.cpp
+++ b/dev/Basic/short/entities/fmodController/FMOD_Client.cpp
@@ -13,6 +13,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <boost/thread.hpp>
+#include <iostream>
 
 namespace sim_mob {
 
@@ -75,7 +76,7 @@ bool FMOD_Client::waitMessageInBlocking(std::string& msg, int seconds)
 
 void FMOD_Client::handleWrite(const boost::system::error_code& error, size_t bytesTransferred)
 {
-    if( error == 0 ){
+    if( error.value() == 0 ){
         std::cout << "sent data : "<<messageSnd<<std::endl;
         sendData();
     }
@@ -85,7 +86,7 @@ void FMOD_Client::handleWrite(const boost::system::error_code& error, size_t byt
 }
 void FMOD_Client::handleRead(const boost::system::error_code& error, size_t bytesTransferred)
 {
-    if( error == 0 ){
+    if( error.value() == 0 ){
         std::cout << "receive data : "<<ReceivedBuf.data()<<std::endl;
         msgReceiveQueue.pushMessage(ReceivedBuf.data(), true);
         ReceivedBuf.assign(0);

--- a/dev/Basic/short/entities/roles/driver/BusDriverFacets.cpp
+++ b/dev/Basic/short/entities/roles/driver/BusDriverFacets.cpp
@@ -301,6 +301,7 @@ std::string BusDriverMovement::frame_tick_output()
         
         return output.str();
     }
+    return {};
 }
 
 void BusDriverMovement::checkForStops(DriverUpdateParams& params)

--- a/dev/Basic/short/entities/roles/driver/MITSIM_LC_Model.cpp
+++ b/dev/Basic/short/entities/roles/driver/MITSIM_LC_Model.cpp
@@ -1581,8 +1581,8 @@ double MITSIM_LC_Model::executeLaneChanging(DriverUpdateParams &params)
                 }
             }
         }
-        return 0.0;
     }
+    return 0.0;
 }
 
 int MITSIM_LC_Model::checkNosingFeasibility(DriverUpdateParams &params, const NearestVehicle *fwdVehicle, const NearestVehicle *rearVehicle, double distToStop)

--- a/dev/Basic/short/entities/roles/driver/OnCallDriver.cpp
+++ b/dev/Basic/short/entities/roles/driver/OnCallDriver.cpp
@@ -219,6 +219,14 @@ void OnCallDriver::subscribeToController()
         << subscribedCtrlr << ", but no controller of that id is registered";
         throw std::runtime_error(msg.str());
     }
+
+    if (!dynamic_cast<OnCallController *>(*it))
+    {
+        std::stringstream msg;
+        msg << "OnCallDriver " << parent->getDatabaseId() << " wants to subscribe to id "
+            << subscribedCtrlr << ", but controller is not of class OnCallController";
+        throw std::runtime_error(msg.str());
+    }
 #endif
 
     MessageBus::PostMessage(*it, MSG_DRIVER_SUBSCRIBE, MessageBus::MessagePtr(new DriverSubscribeMessage(parent)));

--- a/dev/Basic/short/entities/roles/driver/OnCallDriver.cpp
+++ b/dev/Basic/short/entities/roles/driver/OnCallDriver.cpp
@@ -33,9 +33,9 @@ OnCallDriver::~OnCallDriver()
     if(!passengers.empty())
     {
         stringstream msg;
-        msg << "OnCallDriver " << parent->getDatabaseId() << " is being destroyed, but it has "
-            << passengers.size() << " passenger(s).";
-        throw runtime_error(msg.str());
+        Print() << "OnCallDriver " << parent->getDatabaseId() << " is being destroyed, but it has "
+                << passengers.size() << " passenger(s).";
+        //throw runtime_error(msg.str());
     }
 #endif
 }

--- a/dev/Basic/short/entities/roles/passenger/PassengerFacets.hpp
+++ b/dev/Basic/short/entities/roles/passenger/PassengerFacets.hpp
@@ -59,11 +59,13 @@ public:
     //mark startTimeand origin
     virtual TravelMetric & startTravelTimeMetric()
     {
+        return travelMetric;
     }
 
     //mark the destination and end time and travel time
     virtual TravelMetric & finalizeTravelTimeMetric()
     {
+        return travelMetric;
     }
 
     Passenger* getParentPassenger() const


### PR DESCRIPTION
Code cleanup. 
Fixed compile error in unused code tcp_server.cpp.
Removed proj api dependency in unused code Utils.cpp.
Fixed compile error in FMOD_Client.cpp.
Remove use of deprecated function in Constructs.cpp
Removed code that threw exceptions in destructors (-Wterminate)
Fixed incorrect number of arguments passed into sprintf in SegmentStats.cpp.
Removed 2 virtual function from MobilityServiceController class that should have only been defined in OnCallController class.
Fixed all the code that were missing return values (-Wreturn-type)
Fixed CMake error that happens when certain build options are not explicitly specified in cmake command.